### PR TITLE
chore(pre-align): align heading structure (3 docs) with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,7 +1,12 @@
-## Network > Flow Log > Console User Guide
+<!-- pre-align:aligned sig=2aab381b6d86 -->
 
-## Manage Flow Log
-### Create Flow Log
+<a id="network-flow-log-console-user-guide"></a>
+## Network > Flow Log > Console User Guide { #network-flow-log-console-user-guide }
+
+<a id="manage-flow-log"></a>
+## Manage Flow Log { #manage-flow-log }
+<a id="create-flow-log"></a>
+### Create Flow Log { #create-flow-log }
 It can be created through the Create flow log in the NHN Cloud console. For flow logs to work correctly, the flow log system must have access to storage. For more information, see **Granting storage access for flow logs** below.
 
 
@@ -49,27 +54,33 @@ After you click the **Create Flow Log** button, you can set basic information ab
 
 
 
-### Change Flow Log
+<a id="change-flow-log"></a>
+### Change Flow Log { #change-flow-log }
 You can modify the name and description of the flow log by clicking the **Change Flow Log** button.
 
-### Delete Flow Log
+<a id="delete-flow-log"></a>
+### Delete Flow Log { #delete-flow-log }
 You can delete a flow log by clicking the **Delete Flow Log** button.
 
 > [Caution] If the network interface on which the flow logs are being collected is deleted, the flow logs are not deleted. Instead, the **Deleted resource** message is displayed and you must delete the flow logs yourself.
 If the resource being collected is deleted, you will not be charged because the data being collected does not exist.
 
-### Flow Log System Account Information
+<a id="flow-log-system-account-information"></a>
+### Flow Log System Account Information { #flow-log-system-account-information }
 Click **Flow Log System Account Information** to display the **Flow Log Tenant ID** and **Flow Log API User ID** used by the Flow Log system. To use flow logs, you must grant write access to your storage to the corresponding Flow Log tenant ID and Flow Log API user ID. For more information, see **Granting storage access for flow logs** below.
 
 
 
 
-## Grant storage access permissions for flow logs
-### Object Storage
+<a id="grant-storage-access-permissions-for-flow-logs"></a>
+## Grant storage access permissions for flow logs { #grant-storage-access-permissions-for-flow-logs }
+<a id="object-storage"></a>
+### Object Storage { #object-storage }
 If you created a flow log with the storage type specified as object storage (OBS), the flow log system account must have write access to that OBS. If you don't grant write permissions correctly, the flow log system account can't write data to the OBS.
 
 
-### How to set it up
+<a id="how-to-set-it-up"></a>
+### How to set it up { #how-to-set-it-up }
 
 * Access the NHN Cloud > Object Storage console.
 

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,9 +1,13 @@
-## Network > Flow Log > Overview
+<!-- pre-align:aligned sig=3543b2af3ddd -->
+
+<a id="network-flow-log-overview"></a>
+## Network > Flow Log > Overview { #network-flow-log-overview }
 The Flow Log service provides statistics by analyzing packets entering and leaving the network interfaces. This service can be used to view various statistics, such as the number and size of packets allowed or denied by the **Security Groups** rules set on the network interface. With the Flow Log service, you can see if the network interfaces are sending and receiving traffic correctly, who they are communicating with, and if there have been any intrusion attempts from the outside.
 
 
 
-### Main Features
+<a id="main-features"></a>
+### Main Features { #main-features }
 
 * The Flow Log service examines the headers of all packets going to and from a network interface. Currently, it only provides functionality for an instance's network interface and transit hub attachments.
 
@@ -14,7 +18,8 @@ The Flow Log service provides statistics by analyzing packets entering and leavi
 * You can check the statistics to see if **Security Groups** are set up correctly, detect external intrusion attempts, and more.
 
 
-### Service Targets
+<a id="service-targets"></a>
+### Service Targets { #service-targets }
 
 * To collect/view connection information, statistics, etc. of packets coming in and out of ports on your instance
 
@@ -25,7 +30,8 @@ The Flow Log service provides statistics by analyzing packets entering and leavi
 * To enhance the security of your instance by viewing the history of packets coming into your instance and blocking suspicious addresses
 
 
-### Terminology
+<a id="terminology"></a>
+### Terminology { #terminology }
 
 Describes the resources and terminology used by the Flow Log service.
 
@@ -35,7 +41,8 @@ Describes the resources and terminology used by the Flow Log service.
 
 
 
-## Statistics Information Items
+<a id="statistics-information-items"></a>
+## Statistics Information Items { #statistics-information-items }
 The Flow Log service collects and aggregates packets and presents them to you in the following ways:
 
 
@@ -67,7 +74,8 @@ The Flow Log service collects and aggregates packets and presents them to you in
 | 24 | traffic_path | Traffic path of the collected 5-tuple | Integer | Indicates the network path that the packet flowed through with integer values from 1 to 7. <br> \* 1: VPC Local (communication between resources within the same VPC) <br> \* 2: Internet Gateway (outbound internet traffic, including floating IPs) <br> \* 3: VPN Gateway (on-premises connectivity via Site-to-Site VPN) <br> \* 4: VPC Peering (VPC peering within the same project) <br> \* 5: Region Peering (VPC peering between different regions) <br> \* 6: Project Peering (VPC peering between different projects in the same region) <br> \* 7: Service Gateway (Access to internal NHN Cloud services, e.g., Object Storage) |
 
 
-### TCP Flag
+<a id="tcp-flag"></a>
+### TCP Flag { #tcp-flag }
 * If a TCP connection is short-lived, the side initiating the TCP Active Open may send both SYN and FIN within a single collection interval. In this case, SYN | FIN (2 | 1 = 3) is recorded.
 
 
@@ -83,16 +91,19 @@ The Flow Log service collects and aggregates packets and presents them to you in
 * Packets containing only the PSH flag, packets containing only the ACK flag, and the PSH | ACK flag commonly used for general data transmission are excluded from collection. In other words, only SYN, SYN | ACK, FIN | ACK, RST, and FIN are recorded.
 * URG (urgent), ECE (ECN-echo), and CWR (congestion window reduced) are not supported.
 
-## Caution
+<a id="caution"></a>
+## Caution { #caution }
 
-### Collection Interval
+<a id="collection-interval"></a>
+### Collection Interval { #collection-interval }
 * If the collection interval is set too long, traffic from different connections may be collected under the same 5-tuple.
 
     * If connection establishment and termination are repeated multiple times with the same 5-tuple within a collection interval, these connections will be aggregated under the same 5-tuple even if they are logically distinct connections.
 
     * Therefore, it is recommended to configure an appropriate collection interval based on your requirements.
 
-### Traffic not captured by Flow Log
+<a id="traffic-not-captured-by-flow-log"></a>
+### Traffic not captured by Flow Log { #traffic-not-captured-by-flow-log }
 
 * IPv6 traffic is not recorded.
 * Multicast traffic to and from the instance is not recorded.
@@ -101,20 +112,23 @@ The Flow Log service collects and aggregates packets and presents them to you in
 * ARP packets are not recorded.
 * `DROP` events caused by temporary network congestion in the physical equipment containing the instance or in the physical equipment of network services are not subject to collection.
 
-### Important notes for using Flow Log designated for a transit hub connection
+<a id="important-notes-for-using-flow-log-designated-for-a-transit-hub-connection"></a>
+### Important notes for using Flow Log designated for a transit hub connection { #important-notes-for-using-flow-log-designated-for-a-transit-hub-connection }
 
 * Multicast traffic in a transit hub records only packets ingressing into the transit hub based on the transit hub itself. Multicast traffic egressing through one or more connections is not recorded.
 * All packets flowing through a transit hub are recorded once under ACCEPT regardless of whether they are dropped by the transit hub router. Packets actually dropped by the transit hub router are recorded on a separate line with DROP.
 * The transit hub is not affected by the **Connection Setup only** option and collects all packets regardless of the connection state.
 
-### Important notes when using Flow Log designated for load balancers
+<a id="important-notes-when-using-flow-log-designated-for-load-balancers"></a>
+### Important notes when using Flow Log designated for load balancers { #important-notes-when-using-flow-log-designated-for-load-balancers }
 
 * The load balancer currently collects only ACCEPT packets. The collection of packets that are dropped by the IPACL set on the load balancer is expected to be supported in the future.
 
 * In addition to packets attempting to access the load balancer and packets between the load balancer and members, we also collect status check packets.
 * Flow Logs associated with the service are not affected by the **Connection Setup only** option and will collect all packets regardless of the connection state.
 
-### Important notes when using Flow Log on peering gateways and colocation gateways
+<a id="important-notes-when-using-flow-log-on-peering-gateways-and-colocation-gateways"></a>
+### Important notes when using Flow Log on peering gateways and colocation gateways { #important-notes-when-using-flow-log-on-peering-gateways-and-colocation-gateways }
 
 * VPC peering gateway is currently not supported.
 * DROP is not supported because this is not a service that allows users to explicitly set DROP.

--- a/en/public-api.md
+++ b/en/public-api.md
@@ -1,4 +1,7 @@
-## Network > Flow Log > API v2 Guide
+<!-- pre-align:aligned sig=735ec3d72cfa -->
+
+<a id="network-flow-log-api-v2-guide"></a>
+## Network > Flow Log > API v2 Guide { #network-flow-log-api-v2-guide }
 
 The NHN Cloud Network service uses the IaaS token for authentication/authorization when making API calls. The IaaS token is the authentication token used by the NHN Cloud's OpenStack-based infrastructure service (IaaS). For more information on IaaS token issuance and usage, see [IaaS token](/nhncloud/ko/public-api/iaas-token).
 
@@ -11,15 +14,18 @@ The logger and logging port API uses the `network` type endpoint. To see the exa
 API response may show the fields not specified by the guide. These fields are internally used by NHN Cloud, and not used because they are subject to change without prior notice.
 
 
-## Flow Log Logger
+<a id="flow-log-logger"></a>
+## Flow Log Logger { #flow-log-logger }
 
-### List Flow Log Loggers
+<a id="list-flow-log-loggers"></a>
+### List Flow Log Loggers { #list-flow-log-loggers }
 
 ```
 GET /v2.0/flowlog-loggers
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-flow-log-loggers-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -40,6 +46,7 @@ This API does not require a request body.
 | customized_file_name | Query | String | - | File name format of the Flow Log logger to query |
 | status | Query | String | - | Status of the Flow Log logger to query |
 
+<a id="list-flow-log-loggers-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -125,13 +132,15 @@ This API does not require a request body.
 
 ***
 
-### View Flow Log Logger
+<a id="view-flow-log-logger"></a>
+### View Flow Log Logger { #view-flow-log-logger }
 
 ```
 GET /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-flow-log-logger-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -141,6 +150,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | flowlogLoggerId | URL | UUID | O | Flow Log logger ID |
 
+<a id="view-flow-log-logger-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -201,13 +211,15 @@ This API does not require a request body.
 
 ***
 
-### Create Flow Log Logger
+<a id="create-flow-log-logger"></a>
+### Create Flow Log Logger { #create-flow-log-logger }
 
 ```
 POST /v2.0/flowlog-loggers
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-flow-log-logger-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -256,6 +268,7 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="create-flow-log-logger-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -316,13 +329,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### Modify Flow Log Logger
+<a id="modify-flow-log-logger"></a>
+### Modify Flow Log Logger { #modify-flow-log-logger }
 
 ```
 PUT /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modify-flow-log-logger-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -349,6 +364,7 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="modify-flow-log-logger-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -409,13 +425,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### Delete Flow Log Logger
+<a id="delete-flow-log-logger"></a>
+### Delete Flow Log Logger { #delete-flow-log-logger }
 
 ```
 DELETE /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-flow-log-logger-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -425,6 +443,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | flowlogLoggerId | URL | UUID | O | Flow Log logger ID |
 
+<a id="delete-flow-log-logger-response"></a>
 #### Response
 
 This API does not return a response body.
@@ -434,19 +453,22 @@ This API does not return a response body.
 <br>
 
 
-## Flow Log Logging Port
+<a id="flow-log-logging-port"></a>
+## Flow Log Logging Port { #flow-log-logging-port }
 
 * A Flow Log logging port refers to the port that a Flow Log logger actually captures. If the resource_type of the Flow Log logger is VPC or Subnet, a single Flow Log logger manages multiple Flow Log logging ports.
 * When a user creates or deletes a logger, Flow Log internally checks the ports belonging to that logger and adds or removes them as logging port targets. Therefore, users do not need to manually add or remove logging ports.
 * Flow Log logging port only provides Query API.
 
-### List Flow Log Logging Ports
+<a id="list-flow-log-logging-ports"></a>
+### List Flow Log Logging Ports { #list-flow-log-logging-ports }
 
 ```
 GET /v2.0/flowlog-logging-ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-flow-log-logging-ports-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -459,6 +481,7 @@ This API does not require a request body.
 | port_id | Query | UUID | - | ID of port of the Flow Log logging port to query |
 | network_id | Query | UUID | - | VPC ID of the Flow Log to query |
 
+<a id="list-flow-log-logging-ports-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -505,13 +528,15 @@ This API does not require a request body.
 
 ***
 
-### View Flow Log Logging Port
+<a id="view-flow-log-logging-port"></a>
+### View Flow Log Logging Port { #view-flow-log-logging-port }
 
 ```
 GET /v2.0/flowlog-logging-ports/{flowlogLoggingPortId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-flow-log-logging-port-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -521,6 +546,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | flowlogLoggingPortId | URL | UUID | O | Flow Log logging port ID |
 
+<a id="view-flow-log-logging-port-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -555,7 +581,8 @@ This API does not require a request body.
 
 <br><br><br>
 
-## Error Type
+<a id="error-type"></a>
+## Error Type { #error-type }
 
 If the environment to use Flow Log is not configured correctly, an error may occur. In this case, you can look up `flowlog_logger.error_type` to find the cause of the error.
 

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,7 +1,12 @@
-## Network > Flow Log > コンソール使用ガイド
+<!-- pre-align:aligned sig=2aab381b6d86 -->
 
-## フローログ管理
-### フローログの作成
+<a id="network-flow-log-console-user-guide"></a>
+## Network > Flow Log > コンソール使用ガイド { #network-flow-log-console-user-guide }
+
+<a id="manage-flow-log"></a>
+## フローログ管理 { #manage-flow-log }
+<a id="create-flow-log"></a>
+### フローログの作成 { #create-flow-log }
 NHN Cloudのコンソールでフローログ作成画面からフローログを作成できます。フローログが正しく動作するためには、フローログシステムがストレージへのアクセス権を持っている必要があります。詳細は、下部の**フローログのストレージアクセス権限付与**を参照してください。
 
 
@@ -49,27 +54,33 @@ NHN Cloudのコンソールでフローログ作成画面からフローログ�
 
 
 
-### フローログの変更
+<a id="change-flow-log"></a>
+### フローログの変更 { #change-flow-log }
 **フローログ変更**ボタンをクリックして、フローログの名前と説明を変更できます。
 
-### フローログの削除
+<a id="delete-flow-log"></a>
+### フローログの削除 { #delete-flow-log }
 **フローログ削除**ボタンをクリックして、フローログを削除できます。
 
 > [注意]フローログが収集中のネットワークインターフェイスが削除されても、フローログは削除されません。代わりに、**削除されたリソース**というフレーズが表示され、フローログはユーザーが直接削除する必要があります。
 > 収集対象リソースが削除された場合は、収集されるデータが存在しないため、課金はされません。
 
-### フローログシステムアカウント情報
+<a id="flow-log-system-account-information"></a>
+### フローログシステムアカウント情報 { #flow-log-system-account-information }
 **フローログシステムアカウント情報**をクリックすると、フローログシステムが使用する**Flow LogテナントID**と**Flow Log APIユーザーID**が表示されます。フローログを使用するためには、ユーザーのストレージに該当Flow LogテナントID及びFlow Log APIユーザーIDに書き込みアクセス権限を付与する必要があります。詳細は下記の**フローログのストレージへのアクセス権限付与**を参照してください。
 
 
 
 
-## フローログのストレージへのアクセス権限付与
-### Object Storage
+<a id="grant-storage-access-permissions-for-flow-logs"></a>
+## フローログのストレージへのアクセス権限付与 { #grant-storage-access-permissions-for-flow-logs }
+<a id="object-storage"></a>
+### Object Storage { #object-storage }
 ストレージタイプをOBS(object storage)に指定してフローログを作成した場合、フローログシステムアカウントが該当OBSに書き込みでアクセスできる必要があります。もし、書き込み権限を正しく付与していない場合、フローログシステムアカウントはユーザーのOBSにデータを記録できません。
 
 
-### 設定方法
+<a id="how-to-set-it-up"></a>
+### 設定方法 { #how-to-set-it-up }
 
 * NHN Cloud > Object Storageコンソールにアクセスします。
 

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,9 +1,13 @@
-## Network > Flow Log > 概要
+<!-- pre-align:aligned sig=3543b2af3ddd -->
+
+<a id="network-flow-log-overview"></a>
+## Network > Flow Log > 概要 { #network-flow-log-overview }
 Flow Logサービスは、ユーザーのネットワークインターフェースで送受信されるパケットを分析して統計を提供します。このサービスを使用すると、ネットワークインターフェースに設定された**Security Groups**ルールによって許可または拒否されたパケットの数、サイズなど、様々な統計を確認できます。Flow Logサービスを活用すると、ユーザーのネットワークインターフェースが正しくトラフィックを送受信したか、誰と通信を行ったか、そして外部からどのような侵入の試みがあったかなどを確認できます。
 
 
 
-### 主な機能
+<a id="main-features"></a>
+### 主な機能 { #main-features }
 
 * Flow Logサービスは、ネットワークインターフェースで送受信される全てのパケットのヘッダを検査します。現在は、インスタンスのネットワークインターフェースとTransit Hub接続にのみ機能を提供します。
 
@@ -14,7 +18,8 @@ Flow Logサービスは、ユーザーのネットワークインターフェー
 * 統計を確認することで、**Security Groups**が正しく設定されているかどうか、外部からの侵入の試みなどを確認できます。
 
 
-### サービス対象
+<a id="service-targets"></a>
+### サービス対象 { #service-targets }
 
 * インスタンスのポート経由で送受信されるパケットの接続情報、統計などを収集/確認したい場合
 
@@ -25,7 +30,8 @@ Flow Logサービスは、ユーザーのネットワークインターフェー
 * インスタンスへのパケット流入履歴を確認し、疑わしいアドレスを遮断してインスタンスのセキュリティ強化を図りたい場合
 
 
-### 用語
+<a id="terminology"></a>
+### 用語 { #terminology }
 
 Flow Logサービスで使用するリソースと用語を説明します。
 
@@ -35,7 +41,8 @@ Flow Logサービスで使用するリソースと用語を説明します。
 
 
 
-## 統計の提供情報項目
+<a id="statistics-information-items"></a>
+## 統計の提供情報項目 { #statistics-information-items }
 Flow Logサービスがパケットを収集及び集計し、ユーザーに提供する項目は次のとおりです。
 
 
@@ -67,7 +74,8 @@ Flow Logサービスがパケットを収集及び集計し、ユーザーに提
 | 24 | traffic_path | 収集された5-tupleのトラフィック経路 | Integer | パケットが流れたネットワーク経路を1～7の整数値で表記します。<br> * 1: VPC Local(同一VPC内のリソース間通信) <br> * 2: Internet Gateway(インターネットへ送信されるトラフィック、フローティングIPを含む) <br> * 3: VPN Gateway(Site-to-Site VPN経由のオンプレミス接続) <br> * 4: VPC Peering(同じプロジェクト内のVPCピアリング) <br> * 5: Region Peering(異なるリージョン間のVPCピアリング) <br> * 6: Project Peering(異なるプロジェクト、同じリージョンのVPCピアリング) <br> * 7: Service Gateway(NHN Cloud内部サービスへのアクセス、例: Object Storage) |
 
 
-### TCP Flag
+<a id="tcp-flag"></a>
+### TCP Flag { #tcp-flag }
 * TCP接続が短い場合、TCP Active openを試みる側からSYN、FINを収集間隔内に送信することがあります。この場合、SYN \| FIN (2 | 1 = 3)が記録されます。
 
 
@@ -83,16 +91,19 @@ Flow Logサービスがパケットを収集及び集計し、ユーザーに提
 * PSH flagのみ存在するパケット、ACK flagのみ存在するパケット、及び一般的にトラフィックを送信する際に使用するPSH \| ACK flagは収集に含めません。つまり、SYN、SYN \| ACK、FIN \| ACK、RST、FINのみ記録します。
 * URG(urgent)、ECE(ECN-echo)、CWR(congestion window reduced)は提供しません。
 
-## 注意事項
+<a id="caution"></a>
+## 注意事項 { #caution }
 
-### 収集間隔
+<a id="collection-interval"></a>
+### 収集間隔 { #collection-interval }
 * 収集間隔を長く設定した場合、実際には異なる接続であっても同じ5-tupleとして収集される可能性があります。
 
     * 収集間隔内に同一の5-tupleで複数回の接続確立/終了を繰り返すと、これらの接続が論理的にそれぞれ異なる接続であったとしても、同じ5-tupleとして集計されます。
 
     * したがって、状況に応じて適切な収集間隔を設定することを推奨します。
 
-### Flow Logがキャプチャしないトラフィック
+<a id="traffic-not-captured-by-flow-log"></a>
+### Flow Logがキャプチャしないトラフィック { #traffic-not-captured-by-flow-log }
 
 * IPv6トラフィックは記録しません。
 * インスタンスへ送受信されるマルチキャストトラフィックは記録しません。
@@ -101,20 +112,23 @@ Flow Logサービスがパケットを収集及び集計し、ユーザーに提
 * ARPパケットは記録しません。
 * インスタンスを含む物理機器、またはネットワークサービスの物理機器において、一時的なネットワークの輻輳によって発生するDROPは収集対象ではありません。
 
-### Transit Hub接続にFlow Logを指定して使用する際の注意事項
+<a id="important-notes-for-using-flow-log-designated-for-a-transit-hub-connection"></a>
+### Transit Hub接続にFlow Logを指定して使用する際の注意事項 { #important-notes-for-using-flow-log-designated-for-a-transit-hub-connection }
 
 * Transit Hubのマルチキャストトラフィックは、Transit Hubを基準としてTransit Hub経由で流入(ingress)するパケットのみを記録します。1つまたは複数の接続を通じて送信されるマルチキャストトラフィックは記録しません。
 * Transit Hubを流れるパケットは、Transit Hubルーターのドロップの有無に関係なく、全てACCEPTに1回ずつ記録されます。Transit Hubルーターで実際にドロップされたパケットは、別の行にDROPと共に記録されます。
 * Transit Hubは**接続確立パケットのみ収集(connection setup only)**オプションの影響を受けず、接続状態に関係なく全てのパケットを収集します。
 
-### ロードバランサーにFlow Logを指定して使用する際の注意事項
+<a id="important-notes-when-using-flow-log-designated-for-load-balancers"></a>
+### ロードバランサーにFlow Logを指定して使用する際の注意事項 { #important-notes-when-using-flow-log-designated-for-load-balancers }
 
 * 現在、ロードバランサーはACCEPTパケットのみを収集します。ロードバランサーに設定されたIP ACLによってDROPされたパケットの収集は、今後サポートする予定です。
 
 * ロードバランサーへのアクセスを試みるパケット、ロードバランサーとメンバー間の一般パケットだけでなく、ヘルスチェックパケットも一緒に収集します。
 * 該当のサービスに接続されたFlow Logは**接続確立パケットのみ収集(connection setup only)**オプションの影響を受けず、接続状態に関係なく全てのパケットを収集します。
 
-### ピアリングゲートウェイ及びコロケーションゲートウェイにフローログを指定して使用する際の注意事項
+<a id="important-notes-when-using-flow-log-on-peering-gateways-and-colocation-gateways"></a>
+### ピアリングゲートウェイ及びコロケーションゲートウェイにフローログを指定して使用する際の注意事項 { #important-notes-when-using-flow-log-on-peering-gateways-and-colocation-gateways }
 
 * VPCピアリングゲートウェイは現在サポートしていません。
 * ユーザーが明示的にDROPを設定できるサービスではないため、DROPはサポートしていません。

--- a/ja/public-api.md
+++ b/ja/public-api.md
@@ -1,4 +1,7 @@
-## Network > Flow Log > API v2ガイド
+<!-- pre-align:aligned sig=735ec3d72cfa -->
+
+<a id="network-flow-log-api-v2-guide"></a>
+## Network > Flow Log > API v2ガイド { #network-flow-log-api-v2-guide }
 
 NHN Cloud Networkサービスは、API呼び出し時の認証/認可のためにIaaSトークンを使用します。IaaSトークンは、NHN CloudのOpenStackベースのインフラサービス(IaaS)で使用する認証トークンです。IaaSトークンの発行及び使用に関する詳細は、[IaaSトークン](/nhncloud/ja/public-api/iaas-token)を参照してください。
 
@@ -11,15 +14,18 @@ NHN Cloud Networkサービスは、API呼び出し時の認証/認可のため�
 APIレスポンスにガイドに記載されていないフィールドが表示される場合があります。このようなフィールドは、NHN Cloudの内部用途で使用し、予告なく変更される可能性があるため、使用しないでください。
 
 
-## フローログロガー
+<a id="flow-log-logger"></a>
+## フローログロガー { #flow-log-logger }
 
-### フローログロガーリストを見る
+<a id="list-flow-log-loggers"></a>
+### フローログロガーリストを見る { #list-flow-log-loggers }
 
 ```
 GET /v2.0/flowlog-loggers
 X-Auth-Token: {tokenId} 
 ```
 
+<a id="list-flow-log-loggers-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -40,6 +46,7 @@ X-Auth-Token: {tokenId}
 | customized_file_name | Query | String | - | 照会するフローログロガーのファイルタイトル形式 |
 | status | Query | String | - | 照会するフローログロガーの状態 |
 
+<a id="list-flow-log-loggers-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -125,13 +132,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### フローログロガー表示
+<a id="view-flow-log-logger"></a>
+### フローログロガー表示 { #view-flow-log-logger }
 
 ```
 GET /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-flow-log-logger-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -141,6 +150,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | flowlogLoggerId | URL | UUID | O | フローログロガーID |
 
+<a id="view-flow-log-logger-response"></a>
 #### レスポンス
 
 | Name | In | Type | Description |
@@ -201,13 +211,15 @@ X-Auth-Token: {tokenId}
 
 string JP
 
-### フローログロガーを作成する
+<a id="create-flow-log-logger"></a>
+### フローログロガーを作成する { #create-flow-log-logger }
 
 ```
 POST /v2.0/flowlog-loggers
 X-Auth-Token: {tokenId} 
 ```
 
+<a id="create-flow-log-logger-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -256,6 +268,7 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="create-flow-log-logger-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -316,13 +329,15 @@ X-Auth-Token: {tokenId}
 
 string JP
 
-### フローログロガーを修正する
+<a id="modify-flow-log-logger"></a>
+### フローログロガーを修正する { #modify-flow-log-logger }
 
 ```
 PUT /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId} 
 ```
 
+<a id="modify-flow-log-logger-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -349,6 +364,7 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="modify-flow-log-logger-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -409,13 +425,15 @@ X-Auth-Token: {tokenId}
 
 string JP
 
-### フローログロガーを削除する
+<a id="delete-flow-log-logger"></a>
+### フローログロガーを削除する { #delete-flow-log-logger }
 
 ```
 DELETE /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId} 
 ```
 
+<a id="delete-flow-log-logger-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -425,6 +443,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | flowlogLoggerId | URL | UUID | O | フローログロガーID |
 
+<a id="delete-flow-log-logger-response"></a>
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
@@ -434,19 +453,22 @@ X-Auth-Token: {tokenId}
 <br>
 
 
-## フローログロギングポート
+<a id="flow-log-logging-port"></a>
+## フローログロギングポート { #flow-log-logging-port }
 
 * フローログロギングポートとは、フローログロガーが実質的にキャプチャするポートを意味します。フローロガーのresource\_typeがVPCまたはSubnetの場合、1つのフローログロガーが複数のフローログロギングポートを管理することになります。
 * ユーザーがロガーを作成または削除する際、フローログは内部的にそのロガーに属しているポートを確認し、ロギングポート対象として追加または削除を行います。したがって、ユーザーが別途にロギングポートを追加/削除する必要はありません。
 * フローログのロギングポートは、照会APIのみを提供します。
 
-### フローログロギングポートリスト表示
+<a id="list-flow-log-logging-ports"></a>
+### フローログロギングポートリスト表示 { #list-flow-log-logging-ports }
 
 ```
 GET /v2.0/flowlog-logging-ports
 X-Auth-Token: {tokenId} 
 ```
 
+<a id="list-flow-log-logging-ports-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -459,6 +481,7 @@ X-Auth-Token: {tokenId}
 | port_id | Query | UUID | - | 照会するフローログロギングポートのポートID |
 | network_id | Query | UUID | - | 照会するフローログのVPC ID |
 
+<a id="list-flow-log-logging-ports-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -505,13 +528,15 @@ X-Auth-Token: {tokenId}
 
 string JP
 
-### フローログロギングポート表示
+<a id="view-flow-log-logging-port"></a>
+### フローログロギングポート表示 { #view-flow-log-logging-port }
 
 ```
 GET /v2.0/flowlog-logging-ports/{flowlogLoggingPortId}
 X-Auth-Token: {tokenId} 
 ```
 
+<a id="view-flow-log-logging-port-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -521,6 +546,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | flowlogLoggingPortId | URL | UUID | O | フローログロギングポートID |
 
+<a id="view-flow-log-logging-port-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -555,7 +581,8 @@ X-Auth-Token: {tokenId}
 
 <br><br><br>
 
-## エラータイプ
+<a id="error-type"></a>
+## エラータイプ { #error-type }
 
 フローログを使う環境が正しく設定されていない場合、エラーが発生することがあります。この場合、flowlog_logger.error_typeを照会してエラーの原因を確認できます。
 

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,7 +1,12 @@
-## Network > Flow Log > 콘솔 사용 가이드
+<!-- pre-align:aligned sig=2aab381b6d86 -->
 
-## 플로우 로그 관리
-### 플로우 로그 생성
+<a id="network-flow-log-console-user-guide"></a>
+## Network > Flow Log > 콘솔 사용 가이드 { #network-flow-log-console-user-guide }
+
+<a id="manage-flow-log"></a>
+## 플로우 로그 관리 { #manage-flow-log }
+<a id="create-flow-log"></a>
+### 플로우 로그 생성 { #create-flow-log }
 NHN Cloud 콘솔에서 플로우 로그 생성 화면을 통해 생성할 수 있습니다. 플로우 로그가 올바르게 동작하려면 플로우 로그 시스템이 저장소에 접근 권한을 가지고 있어야 합니다. 자세한 내용은 하단의 **플로우 로그의 저장소 접근 권한 부여**를 참고하세요.
 
 
@@ -49,27 +54,33 @@ NHN Cloud 콘솔에서 플로우 로그 생성 화면을 통해 생성할 수 �
 
 
 
-### 플로우 로그 변경
+<a id="change-flow-log"></a>
+### 플로우 로그 변경 { #change-flow-log }
 **플로우 로그 변경** 버튼을 클릭하여 플로우 로그의 이름과 설명을 수정할 수 있습니다.
 
-### 플로우 로그 삭제
+<a id="delete-flow-log"></a>
+### 플로우 로그 삭제 { #delete-flow-log }
 **플로우 로그 삭제** 버튼을 클릭하여 플로우 로그를 삭제할 수 있습니다.
 
 > [주의] 플로우 로그가 수집 중인 네트워크 인터페이스가 삭제되어도 플로우 로그는 삭제되지 않습니다. 대신, **삭제된 리소스** 라는 문구가 노출되며 플로우 로그는 사용자가 직접 삭제해야 합니다. 
 > 수집 대상 리소스가 삭제된 경우에는 수집되는 데이터가 존재하지 않으므로 과금은 되지 않습니다.
 
-### 플로우 로그 시스템 계정 정보
+<a id="flow-log-system-account-information"></a>
+### 플로우 로그 시스템 계정 정보 { #flow-log-system-account-information }
 **플로우 로그 시스템 계정 정보**를 클릭하면 플로우 로그 시스템이 사용하는 **Flow Log 테넌트 ID**와 **Flow Log API 사용자 ID**가 표시됩니다. 플로우 로그를 사용하기 위해서는 사용자의 저장소에 해당 Flow Log 테넌트 ID 및 Flow Log API 사용자 ID에게 쓰기 접근 권한을 부여해야 합니다. 자세한 내용은 아래의 **플로우 로그의 저장소 접근 권한 부여**를 참고하세요.
 
 
 
 
-## 플로우 로그의 저장소 접근 권한 부여
-### Object Storage
+<a id="grant-storage-access-permissions-for-flow-logs"></a>
+## 플로우 로그의 저장소 접근 권한 부여 { #grant-storage-access-permissions-for-flow-logs }
+<a id="object-storage"></a>
+### Object Storage { #object-storage }
 저장소 타입을 OBS(object storage)로 지정하여 플로우 로그를 생성한 경우, 플로우 로그 시스템 계정이 해당 OBS에 쓰기로 접근할 수 있어야 합니다. 만약 쓰기 권한을 올바르게 부여하지 않았다면, 플로우 로그 시스템 계정은 사용자의 OBS에 데이터를 기록할 수 없습니다.
 
 
-### 설정 방법
+<a id="how-to-set-it-up"></a>
+### 설정 방법 { #how-to-set-it-up }
 
 * NHN Cloud > Object Storage 콘솔로 접근합니다.
 

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,9 +1,13 @@
-## Network > Flow Log > 개요
+<!-- pre-align:aligned sig=3543b2af3ddd -->
+
+<a id="network-flow-log-overview"></a>
+## Network > Flow Log > 개요 { #network-flow-log-overview }
 Flow Log 서비스는 사용자의 네트워크 인터페이스로 들어오고 나가는 패킷을 분석하여 통계를 제공합니다. 이 서비스를 사용하면 네트워크 인터페이스에 설정된 **Security Groups** 규칙에 의하여 허용 또는 거부된 패킷의 개수, 크기 등 다양한 통계를 확인할 수 있습니다. Flow Log 서비스를 활용하면 사용자의 네트워크 인터페이스가 올바르게 트래픽을 주고받았는지, 누구와 통신을 수행했는지 그리고 외부에서 어떠한 침입 시도가 있었는지 등을 확인할 수 있습니다.
 
 
 
-### 주요 기능
+<a id="main-features"></a>
+### 주요 기능 { #main-features }
 
 * Flow Log 서비스는 네트워크 인터페이스로 오가는 모든 패킷의 헤더를 검사합니다. 현재는 인스턴스의 네트워크 인터페이스와 트랜짓 허브 연결에만 기능을 제공합니다.
 
@@ -14,7 +18,8 @@ Flow Log 서비스는 사용자의 네트워크 인터페이스로 들어오고 
 * 통계를 확인하여 **Security Groups**의 올바른 설정 여부, 외부 침입 시도 등을 확인할 수 있습니다.
 
 
-### 서비스 대상
+<a id="service-targets"></a>
+### 서비스 대상 { #service-targets }
 
 * 인스턴스의 포트를 통해 들어오고 나가는 패킷의 연결 정보, 통계 등을 수집/확인하고 싶은 경우
 
@@ -25,7 +30,8 @@ Flow Log 서비스는 사용자의 네트워크 인터페이스로 들어오고 
 * 인스턴스로의 패킷 유입 기록을 확인하고 의심스러운 주소를 차단해 인스턴스의 보안 강화를 도모하고 싶은 경우
 
 
-### 용어
+<a id="terminology"></a>
+### 용어 { #terminology }
 
 Flow Log 서비스에서 사용하는 리소스와 용어를 설명합니다.
 
@@ -35,7 +41,8 @@ Flow Log 서비스에서 사용하는 리소스와 용어를 설명합니다.
 
 
 
-## 통계 제공 정보 항목
+<a id="statistics-information-items"></a>
+## 통계 제공 정보 항목 { #statistics-information-items }
 Flow Log 서비스가 패킷을 수집 및 집계하여 사용자에게 제공하는 항목은 다음과 같습니다.
 
 
@@ -67,7 +74,8 @@ Flow Log 서비스가 패킷을 수집 및 집계하여 사용자에게 제공�
 | 24 | traffic_path | 수집된 5-tuple의 트래픽 경로 | Integer | 패킷이 흐른 네트워크 경로를 1~7의 정수 값으로 표기합니다. <br> * 1: VPC Local(동일 VPC 내 리소스 간 통신) <br> * 2: Internet Gateway(인터넷으로 나가는 트래픽, Floating IP 포함) <br> * 3: VPN Gateway(Site-to-Site VPN을 통한 온프레미스 연결) <br> * 4: VPC Peering(같은 프로젝트 내 VPC 피어링) <br> * 5: Region Peering(다른 리전 간 VPC 피어링) <br> * 6: Project Peering(다른 프로젝트, 같은 리전 VPC 피어링) <br> * 7: Service Gateway(NHN Cloud 내부 서비스 접근, 예: Object Storage) |
 
 
-### TCP Flag
+<a id="tcp-flag"></a>
+### TCP Flag { #tcp-flag }
 * TCP 연결이 짧은 경우 TCP Active open을 시도하는 측에서 SYN, FIN을 수집 간격 내에 송신할 수 있습니다. 이때는 SYN \| FIN (2 | 1 = 3)이 기록됩니다.
 
 
@@ -83,16 +91,19 @@ Flow Log 서비스가 패킷을 수집 및 집계하여 사용자에게 제공�
 * PSH flag만 존재하는 패킷, ACK flag만 존재하는 패킷 및 일반적으로 트래픽을 송신할 때 사용하는 PSH \| ACK flag는 수집에 포함하지 않습니다. 즉, SYN, SYN \| ACK, FIN \| ACK, RST, FIN만 기록합니다.
 * URG(urgent), ECE(ECN-echo), CWR(congestion window reduced)는 제공하지 않습니다.
 
-## 주의 사항
+<a id="caution"></a>
+## 주의 사항 { #caution }
 
-### 수집 간격
+<a id="collection-interval"></a>
+### 수집 간격 { #collection-interval }
 * 수집 간격을 길게 설정할 경우, 실제로는 다른 연결이지만 같은 5-tuple로 수집될 수 있습니다.
 
     * 수집 간격 이내에 동일한 5-tuple로 여러 번 연결 수립/종료를 반복하면, 이 연결들이 논리적으로 각자 다른 연결이라고 할지라도 같은 5-tuple로 집계됩니다.
 
     * 따라서 상황에 따라 적절한 수집 간격을 설정하는 것이 좋습니다.
 
-### Flow Log가 캡처하지 않는 트래픽
+<a id="traffic-not-captured-by-flow-log"></a>
+### Flow Log가 캡처하지 않는 트래픽 { #traffic-not-captured-by-flow-log }
 
 * IPv6 트래픽은 기록하지 않습니다.
 * 인스턴스로 오가는 멀티캐스트 트래픽은 기록하지 않습니다.
@@ -101,20 +112,23 @@ Flow Log 서비스가 패킷을 수집 및 집계하여 사용자에게 제공�
 * ARP 패킷은 기록하지 않습니다.
 * 인스턴스를 포함하는 물리적 장비 또는 네트워크 서비스의 물리적 장비에서 일시적인 네트워크 혼잡으로 발생하는 DROP은 수집 대상이 아닙니다.
 
-### 트랜짓 허브 연결에 Flow Log를 지정하여 사용 시 유의 사항
+<a id="important-notes-for-using-flow-log-designated-for-a-transit-hub-connection"></a>
+### 트랜짓 허브 연결에 Flow Log를 지정하여 사용 시 유의 사항 { #important-notes-for-using-flow-log-designated-for-a-transit-hub-connection }
 
 * 트랜짓 허브의 멀티캐스트 트래픽은 트랜짓 허브를 기준으로 트랜짓 허브를 통해 유입(ingress)되는 패킷만 기록합니다. 하나 또는 여러 연결을 통해 나가는 멀티캐스트 트래픽은 기록하지 않습니다.
 * 트랜짓 허브에 흐르는 패킷은 트랜짓 허브 라우터의 드롭 여부와 관계없이 모두 ACCEPT에 한 번씩 기록됩니다. 트랜짓 허브 라우터에서 실제로 드롭된 패킷은 별도의 줄에 DROP과 함께 기록됩니다.
 * 트랜짓 허브는 **연결 수립 패킷만 수집(connection setup only)** 옵션의 영향을 받지 않으며, 연결 상태와 관계없이 모든 패킷을 수집합니다.
 
-### 로드 밸런서에 Flow Log를 지정하여 사용 시 유의 사항
+<a id="important-notes-when-using-flow-log-designated-for-load-balancers"></a>
+### 로드 밸런서에 Flow Log를 지정하여 사용 시 유의 사항 { #important-notes-when-using-flow-log-designated-for-load-balancers }
 
 * 현재 로드 밸런서는 ACCEPT 패킷만을 수집합니다. 로드 밸런서에 설정된 IPACL에 의하여 DROP된 패킷의 수집은 추후 지원 예정입니다.
 
 * 로드 밸런서에 접근을 시도하는 패킷, 로드 밸런서와 멤버 사이의 일반 패킷뿐만 아니라 상태 확인 패킷들도 함께 수집합니다.
 * 해당 서비스에 연결된 Flow Log는 **연결 수립 패킷만 수집(connection setup only)** 옵션의 영향을 받지 않으며, 연결 상태와 관계없이 모든 패킷을 수집합니다.
 
-### 피어링 게이트웨이 및 코로케이션 게이트웨이에 플로우 로그를 지정하여 사용 시 유의 사항
+<a id="important-notes-when-using-flow-log-on-peering-gateways-and-colocation-gateways"></a>
+### 피어링 게이트웨이 및 코로케이션 게이트웨이에 플로우 로그를 지정하여 사용 시 유의 사항 { #important-notes-when-using-flow-log-on-peering-gateways-and-colocation-gateways }
 
 * VPC 피어링 게이트웨이는 현재 지원하지 않습니다.
 * 사용자가 명시적으로 DROP을 설정할 수 있는 서비스가 아니므로, DROP은 지원하지 않습니다.

--- a/ko/public-api.md
+++ b/ko/public-api.md
@@ -1,4 +1,7 @@
-## Network > Flow Log > API v2 가이드
+<!-- pre-align:aligned sig=735ec3d72cfa -->
+
+<a id="network-flow-log-api-v2-guide"></a>
+## Network > Flow Log > API v2 가이드 { #network-flow-log-api-v2-guide }
 
 NHN Cloud Network 서비스는 API 호출 시 인증/인가를 위해 IaaS 토큰을 사용합니다. IaaS 토큰은 NHN Cloud의 OpenStack 기반 인프라 서비스(IaaS)에서 사용하는 인증 토큰입니다. IaaS 토큰 발급 및 사용에 대한 자세한 내용은 [IaaS 토큰](/nhncloud/ko/public-api/iaas-token)을 참고하세요.
 
@@ -11,15 +14,18 @@ NHN Cloud Network 서비스는 API 호출 시 인증/인가를 위해 IaaS 토�
 API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니다. 이런 필드는 NHN Cloud 내부 용도로 사용하며 사전 공지 없이 변경될 수 있으므로 사용하지 않습니다.
 
 
-## Flow Log 로거
+<a id="flow-log-logger"></a>
+## Flow Log 로거 { #flow-log-logger }
 
-### Flow Log 로거 목록 보기
+<a id="list-flow-log-loggers"></a>
+### Flow Log 로거 목록 보기 { #list-flow-log-loggers }
 
 ```
 GET /v2.0/flowlog-loggers
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-flow-log-loggers-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -40,6 +46,7 @@ X-Auth-Token: {tokenId}
 | customized_file_name | Query | String | - | 조회할 Flow Log 로거의 파일 제목 형식 |
 | status | Query | String | - | 조회할 Flow Log 로거의 상태 |
 
+<a id="list-flow-log-loggers-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -125,13 +132,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### Flow Log 로거 보기
+<a id="view-flow-log-logger"></a>
+### Flow Log 로거 보기 { #view-flow-log-logger }
 
 ```
 GET /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-flow-log-logger-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -141,6 +150,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | flowlogLoggerId | URL | UUID | O | Flow Log 로거 ID |
 
+<a id="view-flow-log-logger-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -201,13 +211,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### Flow Log 로거 생성하기
+<a id="create-flow-log-logger"></a>
+### Flow Log 로거 생성하기 { #create-flow-log-logger }
 
 ```
 POST /v2.0/flowlog-loggers
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-flow-log-logger-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -256,6 +268,7 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="create-flow-log-logger-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -316,13 +329,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### Flow Log 로거 수정하기
+<a id="modify-flow-log-logger"></a>
+### Flow Log 로거 수정하기 { #modify-flow-log-logger }
 
 ```
 PUT /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modify-flow-log-logger-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -349,6 +364,7 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="modify-flow-log-logger-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -409,13 +425,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### Flow Log 로거 삭제하기
+<a id="delete-flow-log-logger"></a>
+### Flow Log 로거 삭제하기 { #delete-flow-log-logger }
 
 ```
 DELETE /v2.0/flowlog-loggers/{flowlogLoggerId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-flow-log-logger-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -425,6 +443,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | flowlogLoggerId | URL | UUID | O | Flow Log 로거 ID |
 
+<a id="delete-flow-log-logger-response"></a>
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
@@ -434,19 +453,22 @@ X-Auth-Token: {tokenId}
 <br>
 
 
-## Flow Log 로깅 포트
+<a id="flow-log-logging-port"></a>
+## Flow Log 로깅 포트 { #flow-log-logging-port }
 
 * Flow Log 로깅 포트는 Flow Log 로거가 실질적으로 캡처하는 포트를 의미합니다. Flow Log 로거의 resource\_type이 VPC 또는 Subnet인 경우, 하나의 Flow Log 로거가 여러 개의 Flow Log 로깅 포트를 관리하게 됩니다.
 * 사용자가 로거를 생성 또는 삭제할 때, Flow Log는 내부적으로 해당 로거에 속해 있는 포트를 확인하여 로깅 포트 대상으로 추가 또는 삭제를 수행합니다. 따라서 사용자가 별도로 로깅 포트를 추가/삭제할 필요가 없습니다.
 * Flow Log 로깅 포트는 조회 API만 제공합니다.
 
-### Flow Log 로깅 포트 목록 보기
+<a id="list-flow-log-logging-ports"></a>
+### Flow Log 로깅 포트 목록 보기 { #list-flow-log-logging-ports }
 
 ```
 GET /v2.0/flowlog-logging-ports
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-flow-log-logging-ports-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -459,6 +481,7 @@ X-Auth-Token: {tokenId}
 | port_id | Query | UUID | - | 조회할 Flow Log 로깅 포트의 포트 ID |
 | network_id | Query | UUID | - | 조회할 Flow Log의 VPC ID |
 
+<a id="list-flow-log-logging-ports-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -505,13 +528,15 @@ X-Auth-Token: {tokenId}
 
 ***
 
-### Flow Log 로깅 포트 보기
+<a id="view-flow-log-logging-port"></a>
+### Flow Log 로깅 포트 보기 { #view-flow-log-logging-port }
 
 ```
 GET /v2.0/flowlog-logging-ports/{flowlogLoggingPortId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-flow-log-logging-port-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -521,6 +546,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | flowlogLoggingPortId | URL | UUID | O | Flow Log 로깅 포트 ID |
 
+<a id="view-flow-log-logging-port-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -555,7 +581,8 @@ X-Auth-Token: {tokenId}
 
 <br><br><br>
 
-## 오류 유형
+<a id="error-type"></a>
+## 오류 유형 { #error-type }
 
 Flow Log를 사용하려는 환경이 올바르게 설정되지 않았다면 오류가 발생할 수 있습니다. 이 경우에는 `flowlog_logger.error_type`을 조회하여 오류 원인을 확인할 수 있습니다.
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 3 doc(s) scanned · 9 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/108/ |
| Generated | 2026-07-11T10:21:09 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Flow-Log%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Flow-Log%2Fpull%2F36&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Flow-Log%2Fpull%2F36&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Network-Flow-Log`